### PR TITLE
add pundit policies for all models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3.1)
     rack-test (1.1.0)
@@ -268,6 +270,7 @@ DEPENDENCIES
   jsbundling-rails
   pg (~> 1.1)
   puma (~> 5.0)
+  pundit
   rails (~> 7.0.3)
   sassc-rails
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,21 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  include Pundit::Authorization
+  after_action :verify_authorized, except: :index, unless: :skip_pundit?
+  after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
+
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
 
     # For additional in app/views/devise/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])
+  end
+
+  private
+
+  def skip_pundit?
+    devise_controller? || params[:controller] =~ /(^(rails_)?admin)|(^pages$)/
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/book_policy.rb
+++ b/app/policies/book_policy.rb
@@ -1,0 +1,8 @@
+class BookPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/copy_policy.rb
+++ b/app/policies/copy_policy.rb
@@ -1,0 +1,8 @@
+class CopyPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/handover_policy.rb
+++ b/app/policies/handover_policy.rb
@@ -1,0 +1,8 @@
+class HandoverPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,0 +1,8 @@
+class LocationPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -1,0 +1,8 @@
+class MeetingPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/user_location_policy.rb
+++ b/app/policies/user_location_policy.rb
@@ -1,0 +1,8 @@
+class UserLocationPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/test/policies/book_policy_test.rb
+++ b/test/policies/book_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class BookPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/copy_policy_test.rb
+++ b/test/policies/copy_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class CopyPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/handover_policy_test.rb
+++ b/test/policies/handover_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class HandoverPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/location_policy_test.rb
+++ b/test/policies/location_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class LocationPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/meeting_policy_test.rb
+++ b/test/policies/meeting_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class MeetingPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/user_location_policy_test.rb
+++ b/test/policies/user_location_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class UserLocationPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
add pundit policies for all models
make index and show authorized for everybody
IMPORTANT NOTE:
In case needed, one has to set the authorisation process manually under the controller actions!
example (Authorize @restaurant in the show action):
# app/controllers/restaurants_controller.rb

def destroy
  authorize @restaurant
end

# app/policies/restaurant_policy.rb
class RestaurantPolicy < ApplicationPolicy
  def destroy?
    record.user == user
  end
end