### PR TITLE
rearrange home search field and format select menu

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row mx-auto">
       <%= form_tag root_path, method: :get do %>
-        <%= select_tag "district", options_for_select(@districts, params[:district].nil? ? "All areas" : params[:district]), {class: "col-12 form-select"} %>
+          <%= select_tag "district", options_for_select(@districts, params[:district].nil? ? "All areas" : params[:district]), {class: "col-12 form-select"} %>
         <div class="d-flex">
           <%= text_field_tag :query,
                               params[:query],

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,14 +3,16 @@
   <h4 class="text-center">Find books in your area</h4>
   <div class="container">
     <div class="row mx-auto">
-      <%= form_tag root_path, method: :get, class: "d-flex" do %>
-        <%= select_tag "district", options_for_select(@districts, params[:district].nil? ? "All areas" : params[:district]), {class: "col-4"} %>
-        <%= text_field_tag :query,
-                            params[:query],
-                            class: "form-control",
-                            placeholder: "Search here" %>
-        <%= button_tag class: "btn btn-success" do %>
+      <%= form_tag root_path, method: :get do %>
+        <%= select_tag "district", options_for_select(@districts, params[:district].nil? ? "All areas" : params[:district]), {class: "col-12 form-select"} %>
+        <div class="d-flex">
+          <%= text_field_tag :query,
+                              params[:query],
+                              class: "form-control",
+                              placeholder: "Search here" %>
+          <%= button_tag class: "btn btn-success" do %>
           <i class='fas fa-search'></i>
+        </div>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
rearrange home search field and format select menu

*for the areas selector we cannot use BS dropdown because it is technically a form's select element and not a button. However, there is a BS class for this too which makes the design match the form-control class.