### PR TITLE
add expandable location cards to book show page

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -7,3 +7,4 @@
 @import "profile";
 @import "book_cover";
 @import "chatroom";
+@import "location_card";

--- a/app/assets/stylesheets/components/_location_card.scss
+++ b/app/assets/stylesheets/components/_location_card.scss
@@ -1,0 +1,20 @@
+.card-location {
+  background-size: cover;
+  background-position: center;
+  height: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-size: 24px;
+  font-weight: bold;
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.7);
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  position: relative;
+}
+
+.card-location .card-location-users {
+  position: absolute;
+  left: 9px;
+  bottom: 4px;
+}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -22,7 +22,6 @@ class BooksController < ApplicationController
     # get distinct list of locations where users are willing to meet
     @locations_uniq = @locations.map.uniq
     # select book users from book locations
-    # @location_book_users = @locations_uniq.map { |location| location.users & @book_users }
     @location_book_users = []
     @locations_uniq.each do |location|
       @location_book_users += location.users & @book_users

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -4,8 +4,8 @@ class BooksController < ApplicationController
   def show
     @book = Book.find(params[:id])
     authorize @book # authorize @book for pundit
-    # get users that have the selected book
-    @book_users = @book.users
+    # get users that have the selected book, but ignore current_user
+    @book_users = @book.users - [current_user]
     # match book users with selected district, e. g. "Neukölln"
     @locations = []
     # check if params[:district] was passed
@@ -20,6 +20,14 @@ class BooksController < ApplicationController
       end
     end
     # get distinct list of locations where users are willing to meet
-    @locations_uniq = @locations.map { |location| location }.uniq
+    @locations_uniq = @locations.map.uniq
+    # select book users from book locations
+    # @location_book_users = @locations_uniq.map { |location| location.users & @book_users }
+    @location_book_users = []
+    @locations_uniq.each do |location|
+      @location_book_users += location.users & @book_users
+    end
+    # get distinct list of book users at book locations
+    @location_book_users_uniq = @location_book_users.uniq
   end
 end

--- a/app/models/chatroom.rb
+++ b/app/models/chatroom.rb
@@ -1,3 +1,4 @@
 class Chatroom < ApplicationRecord
   has_many :messages, dependent: :destroy
+  has_one :meeting
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -36,12 +36,12 @@
             <div id="flush-collapse<%= location.id %>" class="accordion-collapse collapse" aria-labelledby="flush-heading<%= location.id %>" data-bs-parent="#accordionFlushExample">
               <div class="accordion-body bg-white">
                 <%# show users that offer the book at this location %>
-                <p class="m-0">Set up a meeting with:</p>
+                <p><small class="m-0">Set up a meeting with:</small></p>
                 <%# iterate over available users at location %>
                 <% location.users.each do |user| %>
                   <% if (user.copies.find_by book_id: params[:id]) %>
                     <% unless user == current_user %>
-                      <%= link_to user.username, new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])) %>
+                      <p class="m-1"><%= link_to user.username, new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])) %></p>
                     <% end %>
                   <% end %>
                 <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -19,7 +19,6 @@
     <% else %>
       <%# iterate over available locations %>
       <% @locations_uniq.each do |location| %>
-        <%# BUGFIX: filter locations that only belong to the current user %>
         <div class="accordion accordion-flush">
           <div class="accordion-item mt-2">
             <div class="accordion-header" id="flush-heading<%= location.id %>">

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -41,7 +41,12 @@
                 <% location.users.each do |user| %>
                   <% if (user.copies.find_by book_id: params[:id]) %>
                     <% unless user == current_user %>
-                      <p class="m-1"><%= link_to user.username, new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])) %></p>
+                      <%= link_to new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])), class: "text-decoration-none" do %>
+                        <div class="d-flex align-items-center mb-1 gap-1" >
+                          <%= image_tag "https://kitt.lewagon.com/placeholder/users/#{user.id}", class: "avatar" %>
+                          <small><%= user.username %></small>
+                        </div>
+                      <% end %>
                     <% end %>
                   <% end %>
                 <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -4,7 +4,7 @@
     <h2><%= @book.title %></h2>
     <p>by <%= @book.author %></p>
     <span>Description:</span>
-    <p><%= @book.description %></p>
+    <p><small><%= @book.description %></small></p>
     <span>Published:</span>
     <p><%= @book.year %></p>
     <span>ISBN:</span>
@@ -13,21 +13,42 @@
   <hr>
   <div class="container">
     <h1>Locations:</h1>
+    <%# accordion %>
     <% if @locations_uniq.empty? %>
       <p><em>Sorry, but this book is currently not available...</em></p>
     <% else %>
+      <%# iterate over available locations %>
       <% @locations_uniq.each do |location| %>
-        <div class="container mb-3">
-          <h4 class="m-0"><%= location.name %></h4>
-          <%# show users that offer the book at this location %>
-          <p class="m-0">Set up a meeting with:</p>
-          <% location.users.each do |user| %>
-            <% if (user.copies.find_by book_id: params[:id]) %>
-              <% unless user == current_user %>
-                <%= link_to user.username, new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])) %>
-              <% end %>
-            <% end %>
-          <% end %>
+        <%# BUGFIX: filter locations that only belong to the current user %>
+        <div class="accordion accordion-flush">
+          <div class="accordion-item mt-2">
+            <div class="accordion-header" id="flush-heading<%= location.id %>">
+              <div class="button collapsed card-location text-white"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapse<%= location.id %>"
+                    aria-expanded="false"
+                    aria-controls="flush-collapse<%= location.id %>"
+                    style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://images.unsplash.com/photo-1507550284711-08dadbf8621f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Ym9vayUyMGNhZmV8ZW58MHwwfDB8fA%3D%3D&auto=format&fit=crop&w=900&q=60)"
+              >
+                <%= location.name %>
+                <span class="fs-6 card-location-users"><i class="fa-solid fa-user-group"></i> <%= (location.users & @location_book_users_uniq).count %></span>
+              </div>
+            </div>
+            <div id="flush-collapse<%= location.id %>" class="accordion-collapse collapse" aria-labelledby="flush-heading<%= location.id %>" data-bs-parent="#accordionFlushExample">
+              <div class="accordion-body bg-white">
+                <%# show users that offer the book at this location %>
+                <p class="m-0">Set up a meeting with:</p>
+                <%# iterate over available users at location %>
+                <% location.users.each do |user| %>
+                  <% if (user.copies.find_by book_id: params[:id]) %>
+                    <% unless user == current_user %>
+                      <%= link_to user.username, new_meeting_path(location: location, copy: (user.copies.find_by book_id: params[:id])) %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          </div>
         </div>
       <% end %>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,7 +39,6 @@
               <div class="accordion-body bg-white">
                 <small>Address:</small>
                 <p class="m-0"><%= location_of_user.address %></p>
-                <p class="m-0">(<%= location_of_user.district %>)</p>
               </div>
             </div>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,11 +18,32 @@
     <p>You currently have no locations</p>
   <% else %>
     <div class="container mb-3">
-      <% @user_locations.each do |user_location| %>
-        <h4 class="mt-3 mb-1"><%= user_location.location.name %></h4>
-        <p class="m-0"><%= user_location.location.address %>, <%= user_location.location.zipcode %> Berlin</p>
-        <p class="m-0"><%= user_location.location.district %></p>
-        <%= link_to "Delete", user_path(user_location), class: "btn btn-danger btn-sm", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
+      <% @locations_of_user.each do |location_of_user| %>
+        <div class="accordion accordion-flush">
+          <div class="accordion-item mt-2">
+            <div class="accordion-header" id="flush-heading<%= location_of_user.id %>">
+              <div class="button collapsed card-location text-white"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapse<%= location_of_user.id %>"
+                    aria-expanded="false"
+                    aria-controls="flush-collapse<%= location_of_user.id %>"
+                    style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://images.unsplash.com/photo-1507550284711-08dadbf8621f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Ym9vayUyMGNhZmV8ZW58MHwwfDB8fA%3D%3D&auto=format&fit=crop&w=900&q=60)"
+              >
+                <%= location_of_user.name %>
+                  <%= link_to user_path(location_of_user), class: "fs-6 card-location-users text-white", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+                    <i class="fa-solid fa-trash-can"></i>
+                  <% end %>
+              </div>
+            </div>
+            <div id="flush-collapse<%= location_of_user.id %>" class="accordion-collapse collapse" aria-labelledby="flush-heading<%= location_of_user.id %>" data-bs-parent="#accordionFlushExample">
+              <div class="accordion-body bg-white">
+                <small>Address:</small>
+                <p class="m-0"><%= location_of_user.address %></p>
+                <p class="m-0">(<%= location_of_user.district %>)</p>
+              </div>
+            </div>
+          </div>
+        </div>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
1) BUGFIX: exclude locations that only belong to the current user
2) add expandable location cards to book show page
3) add association to chatroom model
4) adjust location card for user show page and remove district from dropdown menu
5) add list of avatars and usernames to dropdown menu of location card on book show page